### PR TITLE
Formatting for Terraform Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,31 +6,13 @@ Modular NAT Gateway on Google Compute Engine for Terraform.
 
 ```ruby
 module "nat" {
-  source  = "github.com/GoogleCloudPlatform/terraform-google-nat-gateway"
+  source  = "GoogleCloudPlatform/nat-gateway/google"
   region  = "us-central1"
   network = "default"
 }
 ```
 
 Add the `nat-REGION` tag to your instances without external IPs to route outbound traffic through the nat gateway.
-
-### Input variables
-
-- `region` (required): The region to create the nat gateway instance in.
-- `zone` (optional): Override the zone used in the `region_params` map for the region.
-- `network` (optional): The network to deploy to.
-- `subnetwork` (optional): The subnetwork to deploy to.
-- `tags` (optional): List of additional compute instance network tags to apply route to. Default is `["nat-REGION"]`.
-- `route_priority` (optional): The priority for the Compute Engine Route. Default is `800`.
-- `ip` (optional): Override the IP used in the `region_params` map for the region.
-- `squid_enabled` (optional): Enable squid3 proxy on port 3128. Default is `false`
-- `squid_config` (optional): The squid config file to use. If not specifed the module file config/squid.conf will be used.
-
-### Output variables 
-
-- `depends_id`: Value that can be used for intra-module dependency creation.
-- `gateway_ip`: The internal IP address of the NAT gateway instance.
-- `external_ip`: The external IP address of the NAT gateway instance.
 
 ## Resources created
 


### PR DESCRIPTION
Hi there,

renamed the path of the source to the module registry instead of the GitHub repo

removed variables because all variable information is sourced from the variable and output files.

If you can merge this into master and then add another release/tag so that the module registry will update. After that we'll be able to verify this module.

Thanks
Chris