### PR TITLE
added subnetwork to example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Modular NAT Gateway on Google Compute Engine for Terraform.
 
 ```ruby
 module "nat" {
-  source  = "GoogleCloudPlatform/nat-gateway/google"
-  region  = "us-central1"
-  network = "default"
+  source     = "GoogleCloudPlatform/nat-gateway/google"
+  region     = "us-central1"
+  network    = "default"
+  subnetwork = "default"
 }
 ```
 


### PR DESCRIPTION
Fixes #3 by explicitly setting the `subnetwork` input variable in the example usage.