### PR TITLE
ha-nat-gateway example - document the need to have ssh-agent running.

### DIFF
--- a/examples/ha-nat-gateway/README.md
+++ b/examples/ha-nat-gateway/README.md
@@ -25,7 +25,7 @@ SSH into the instance by hopping through one of the NAT gateway instances, first
 
 ```
 eval ssh-agent $SHELL
-ssh-add ~/.ssh/[YOUR_PRIVATE_KEY]
+ssh-add ~/.ssh/google_compute_engine
 gcloud compute ssh $(gcloud compute instances list --filter=name~nat-gateway- --limit=1 --uri) --ssh-flag="-A" -- ssh $(gcloud compute instances list --filter=name~group1- --limit=1 --format='value(name)')
 ```
 

--- a/examples/ha-nat-gateway/README.md
+++ b/examples/ha-nat-gateway/README.md
@@ -21,9 +21,11 @@ terraform plan
 terraform apply
 ```
 
-SSH into the instance by hopping through one of the NAT gateway instances.
+SSH into the instance by hopping through one of the NAT gateway instances, first make sure that SSH agent is running and your private SSH key is added to the authentication agent.
 
 ```
+eval ssh-agent $SHELL
+ssh-add ~/.ssh/[YOUR_PRIVATE_KEY]
 gcloud compute ssh $(gcloud compute instances list --filter=name~nat-gateway- --limit=1 --uri) --ssh-flag="-A" -- ssh $(gcloud compute instances list --filter=name~group1- --limit=1 --format='value(name)')
 ```
 


### PR DESCRIPTION
 Document the need to have  ssh-agent running and private key to be added to the authentication agent before issuing "gcloud compute ssh" command.