### PR TITLE
fix: remove dash from name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ module "nat-gateway" {
 }
 
 resource "google_compute_route" "nat-gateway" {
-  name                   = "${var.name}-nat-${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"
+  name                   = "${var.name}nat-${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"
   project                = "${var.project}"
   dest_range             = "0.0.0.0/0"
   network                = "${data.google_compute_network.network.self_link}"


### PR DESCRIPTION
This fix avoids the following error:
google_compute_route.nat-gateway: Error creating route: googleapi: Error 400: Invalid value for field 'resource.name': '-nat-xxx-xxx1-b'. Must be a match of regex '(?:[a
-z](?:[-a-z0-9]{0,61}[a-z0-9])?)', invalid