### PR TITLE
[GKE Example] Support for Regional and Private Clusters

### DIFF
--- a/examples/gke-nat-gateway/README.md
+++ b/examples/gke-nat-gateway/README.md
@@ -17,17 +17,26 @@ This example assumes you have an existing Container Engine cluster.
 
 ### Get Master IP and Node Tags
 
-Record the target cluster name:
+Record the target cluster name, region and zone:
 
 ```
 CLUSTER_NAME=dev
+REGION=us-central1
+ZONE=us-central1-b
 ```
 
-Save the IP address of the GKE master and the node pool nework tag name to the tfvars file:
+Create a `terraform.tfvars` file with the the region, zone, master IP, and the node pool nework tag name to the tfvars file:
 
 ```
-echo "gke_master_ip = \"$(gcloud container clusters list --filter="name~${CLUSTER_NAME}" --format='value("endpoint")')\"" > terraform.tfvars
-echo "gke_node_tag = \"$(gcloud compute instance-templates describe $(gcloud compute instance-templates list --filter=name~gke-${CLUSTER_NAME} --limit=1 --uri) --format='get(properties.tags.items[0])')\"" >> terraform.tfvars
+NODE_TAG=$(gcloud compute instance-templates describe $(gcloud compute instance-templates list --filter=name~gke-${CLUSTER_NAME} --limit=1 --uri) --format='get(properties.tags.items[0])')
+MASTER_IP=$(gcloud compute firewall-rules describe ${NODE_TAG/-node/-ssh} --format='value(sourceRanges)')
+
+cat > terraform.tfvars <<EOF
+region = "${REGION}"
+zone   = "${ZONE}"
+gke_master_ip = "${MASTER_IP}"
+gke_node_tag = "${NODE_TAG}"
+EOF
 ```
 
 ## Run Terraform
@@ -40,20 +49,28 @@ terraform apply
 
 ## Verify NAT Gateway Routing
 
-Run a sample app to inspect the external IP seen by a pod:
+Show the external IP address that the cluster node is using by running a Kubernetes pod that uses curl:
 
 ```
-kubectl run example --image centos:7 -- bash -c 'while true; do curl -s http://ipinfo.io/ip; sleep 5; done'
-```
-
-```
-kubectl logs --tail=10 $(kubectl get pods --selector=run=example --output='jsonpath={.items..metadata.name}')
+kubectl run example -i -t --rm --restart=Never --image centos:7 -- curl -s http://ipinfo.io/ip
 ```
 
 The IP address shown in the pod output should match the value of the NAT Gateway `external_ip`. Get the external IP of the NAT Gateway by running the command below:
 
 ```
-terraform output -module=nat -json | jq -r .external_ip.value
+terraform output
+```
+
+## Caveats
+
+1. The web console SSH will no longer work, you have to jump through the NAT gateway machine to SSH into a GKE node:
+
+```
+eval ssh-agent $SHELL
+ssh-add ~/.ssh/google_compute_engine
+CLUSTER_NAME=dev
+REGION=us-central1
+gcloud compute ssh $(gcloud compute instances list --filter=name~nat-gateway-${REGION} --uri) --ssh-flag="-A" -- ssh $(gcloud compute instances list --filter=name~gke-${CLUSTER_NAME}- --limit=1 --format='value(name)') -o StrictHostKeyChecking=no
 ```
 
 ## Cleanup

--- a/examples/gke-nat-gateway/README.md
+++ b/examples/gke-nat-gateway/README.md
@@ -17,17 +17,16 @@ This example assumes you have an existing Container Engine cluster.
 
 ### Get Master IP and Node Tags
 
-Record the target cluster name and zone:
+Record the target cluster name:
 
 ```
 CLUSTER_NAME=dev
-ZONE=us-central1-f
 ```
 
 Save the IP address of the GKE master and the node pool nework tag name to the tfvars file:
 
 ```
-echo "gke_master_ip = \"$(gcloud container clusters describe ${CLUSTER_NAME} --zone ${ZONE} --format='get(endpoint)')\"" > terraform.tfvars
+echo "gke_master_ip = \"$(gcloud container clusters list --filter="name~${CLUSTER_NAME}" --format='value("endpoint")')\"" > terraform.tfvars
 echo "gke_node_tag = \"$(gcloud compute instance-templates describe $(gcloud compute instance-templates list --filter=name~gke-${CLUSTER_NAME} --limit=1 --uri) --format='get(properties.tags.items[0])')\"" >> terraform.tfvars
 ```
 

--- a/examples/gke-nat-gateway/main.tf
+++ b/examples/gke-nat-gateway/main.tf
@@ -57,3 +57,7 @@ resource "google_compute_route" "gke-master-default-gw" {
   tags             = ["${var.gke_node_tag}"]
   priority         = 700
 }
+
+output "ip-nat-gateway" {
+  value = "${module.nat.external_ip}"
+}

--- a/examples/lb-http-nat-gateway/main.tf
+++ b/examples/lb-http-nat-gateway/main.tf
@@ -69,3 +69,7 @@ module "gce-lb-http" {
     "/,http,80,10",
   ]
 }
+
+output "ip-nat-gateway" {
+  value = "${module.nat-gateway.external_ip}"
+}

--- a/examples/multiple-nat-environments/main.tf
+++ b/examples/multiple-nat-environments/main.tf
@@ -130,3 +130,11 @@ module "gce-lb-http" {
     "/,http,80,10",
   ]
 }
+
+output "ip-nat-staging" {
+  value = "${module.staging-nat-gateway.external_ip}"
+}
+
+output "ip-nat-production" {
+  value = "${module.production-nat-gateway.external_ip}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,6 +24,11 @@ output gateway_ip {
   value       = "${module.nat-gateway.network_ip}"
 }
 
+output instance {
+  description = "The self link to the NAT gateway instance."
+  value       = "${element(module.nat-gateway.instances[0], 0)}"
+}
+
 output external_ip {
   description = "The external IP address of the NAT gateway instance."
   value       = "${data.google_compute_address.default.address}"


### PR DESCRIPTION
Fixes #25 

- Add multiple routes for multiple master IPs when using regional clusters. 
- Omit master route when using private clusters (var.gke_master_ip is empty)
- Backwards compatible with old var.gke_master_ip format.