### PR TITLE
Issue 27 project missing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,8 +47,9 @@ data "google_compute_network" "network" {
 }
 
 data "google_compute_address" "default" {
-  name   = "${element(concat(google_compute_address.default.*.name, list("${var.ip_address_name}")), 0)}"
-  region = "${var.region}"
+  name    = "${element(concat(google_compute_address.default.*.name, list("${var.ip_address_name}")), 0)}"
+  project = "${var.network_project == "" ? var.project : var.network_project}"
+  region  = "${var.region}"
 }
 
 module "nat-gateway" {

--- a/main.tf
+++ b/main.tf
@@ -73,9 +73,11 @@ module "nat-gateway" {
   // Race condition when creating route with instance in managed instance group. Wait 30 seconds for the instance to be created by the manager.
   local_cmd_create = "sleep 30"
 
-  access_config = [{
-    nat_ip = "${data.google_compute_address.default.address}"
-  }]
+  access_config = [
+    {
+      nat_ip = "${data.google_compute_address.default.address}"
+    },
+  ]
 }
 
 resource "google_compute_route" "nat-gateway" {


### PR DESCRIPTION
This is to fix #27 - which results when a default project is not set.

Following the example of the other resources, this sets the `project` explicitly for the `data.google_compute_address`.

Defaults tot project where NAT is being built, unless `network_project` var is specified. As per the `data.google_compute_network` lookup.