### PR TITLE
Making module disable-able

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,7 @@ data "google_compute_address" "default" {
 
 module "nat-gateway" {
   source             = "github.com/GoogleCloudPlatform/terraform-google-managed-instance-group"
+  module_enabled     = "${var.module_enabled}"
   project            = "${var.project}"
   region             = "${var.region}"
   zone               = "${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"
@@ -62,6 +63,7 @@ module "nat-gateway" {
 }
 
 resource "google_compute_route" "nat-gateway" {
+  count                  = "${var.module_enabled ? 1 : 0}"
   name                   = "${var.name}nat-${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"
   project                = "${var.project}"
   dest_range             = "0.0.0.0/0"
@@ -73,6 +75,7 @@ resource "google_compute_route" "nat-gateway" {
 }
 
 resource "google_compute_firewall" "nat-gateway" {
+  count   = "${var.module_enabled ? 1 : 0}"
   name    = "${var.name}nat-${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"
   network = "${var.network}"
   project = "${var.project}"
@@ -86,7 +89,7 @@ resource "google_compute_firewall" "nat-gateway" {
 }
 
 resource "google_compute_address" "default" {
-  count   = "${var.ip_address_name == "" ? 1 : 0}"
+  count   = "${var.module_enabled && var.ip_address_name == "" ? 1 : 0}"
   name    = "${var.name}nat-${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"
   project = "${var.project}"
   region  = "${var.region}"

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,8 @@ data "google_compute_network" "network" {
 }
 
 data "google_compute_address" "default" {
-  name    = "${element(concat(google_compute_address.default.*.name, list("${var.ip_address_name}")), 0)}"
+  count   = "${var.ip_address_name == "" ? 0 : 1}"
+  name    = "${var.ip_address_name}"
   project = "${var.network_project == "" ? var.project : var.network_project}"
   region  = "${var.region}"
 }
@@ -57,7 +58,7 @@ module "nat-gateway" {
 
   access_config = [
     {
-      nat_ip = "${var.ip_address_name == "" ? google_compute_address.default.address : data.google_compute_address.default.address}"
+      nat_ip = "${element(concat(google_compute_address.default.*.address, data.google_compute_address.default.*.address, list("")), 0)}"
     },
   ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,12 +26,12 @@ output gateway_ip {
 
 output instance {
   description = "The self link to the NAT gateway instance."
-  value       = "${element(module.nat-gateway.instances[0], 0)}"
+  value       = "${flatten(module.nat-gateway.instances)}"
 }
 
 output external_ip {
   description = "The external IP address of the NAT gateway instance."
-  value       = "${data.google_compute_address.default.address}"
+  value       = "${element(concat(google_compute_address.default.*.address, data.google_compute_address.default.*.address, list("")), 0)}"
 }
 
 output routing_tag_regional {

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+variable module_enabled {
+  description  = "To disable this module, set this to false"
+  default      = true
+}
+
 variable project {
   description = "The project to deploy to, if not set the default provider project is used."
   default     = ""


### PR DESCRIPTION
## Purpose

Wanted to be able to disable this module from a variable, so for a "dev" env you could have just one NAT gateway, and a "live" env you could have 3, without requiring .tf file editing.  This is necessary because you can't use the Terraform `count` feature on a module.  Eg:

```
module "nat-zone-1" {
  source         = "../terraform-google-nat-gateway"
  name           = "myproject-"
  region         = "${var.region}"
  zone           = "${var.zones[0]}"
  network        = "${google_compute_subnetwork.default.name}"
  subnetwork     = "${google_compute_subnetwork.default.name}"
}

# If on live, add the second zone NAT
module "nat-zone-2" {
  source         = "../terraform-google-nat-gateway"
  module_enabled = "${var.is_live ? true : false}"
  name           = "myproject-"
  region         = "${var.region}"
  zone           = "${var.zones[1]}"
  network        = "${google_compute_subnetwork.default.name}"
  subnetwork     = "${google_compute_subnetwork.default.name}"
}
# If on live, add the third zone NAT
module "nat-zone-3" {
  source         = "../terraform-google-nat-gateway"
  module_enabled = "${var.is_live ? true : false}"
  name           = "myproject-"
  region         = "${var.region}"
  zone           = "${var.zones[2]}"
  network        = "${google_compute_subnetwork.default.name}"
  subnetwork     = "${google_compute_subnetwork.default.name}"
}
```

## What I did...

* Added a new variable module_enabled, in the same nature as is used in the terraform-google-managed-instance-group Terraform repository.
* Made all resources use the `count` feature linked to the module_enabled var to enable/disable
* Removed the unnecessary `data.google_compute_address` which prevented the module disable-able feature, using address from the resource.google_compute_address instead.