### PR TITLE
Allow custom instance metadata for NAT gateway.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,8 @@ module "nat-gateway" {
   startup_script     = "${data.template_file.nat-startup-script.rendered}"
   wait_for_instances = true
 
+  metadata = "${var.metadata}"
+
   access_config = [
     {
       nat_ip = "${data.google_compute_address.default.address}"

--- a/variables.tf
+++ b/variables.tf
@@ -69,6 +69,12 @@ variable machine_type {
   default     = "n1-standard-1"
 }
 
+variable metadata {
+  description = "Metadata to be attached to the NAT gateway instance"
+  type        = "map"
+  default     = {}
+}
+
 variable ip {
   description = "Override the IP used in the `region_params` map for the region."
   default     = ""


### PR DESCRIPTION
I needed this in order to be able to add the `enable-oslogin` metadata keypair, but it could be re-purposed as required by users.

