### PR TITLE
chore(main.tf) upgrade debian image to v9

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ module "nat-gateway" {
   target_tags        = ["${var.name}nat-${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"]
   machine_type       = "${var.machine_type}"
   name               = "${var.name}nat-gateway-${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"
-  compute_image      = "debian-cloud/debian-8"
+  compute_image      = "debian-cloud/debian-9"
   size               = 1
   network_ip         = "${var.ip}"
   can_ip_forward     = "true"


### PR DESCRIPTION
Debian 8 "Jessie" operating system will reach its planned end-of-life on June 18, 2018.