### PR TITLE
Output with tags for easier integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,22 @@ module "nat" {
 }
 ```
 
-Add the `nat-REGION-ZONE` and  `nat-REGION` tags to your instances without external IPs to route outbound traffic through the nat gateway.
+And add the tag `${module.nat.routing_tag_regional}` or `${module.nat.routing_tag_zonal}` to your instances without external IPs to route outbound traffic through the nat gateway.
+
+## Usage
+
+```ruby
+module "mig" {
+  source      = "github.com/GoogleCloudPlatform/terraform-google-managed-instance-group"
+  region      = "us-central1"
+  zone        = "us-central1-a"
+  name        = "testnat"
+  target_tags = ["${module.nat.routing_tag_regional}"]
+  network     = "default"
+  subnetwork  = "default"
+}
+```
+
 
 ## Resources created
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,3 +33,13 @@ output external_ip {
   description = "The external IP address of the NAT gateway instance."
   value       = "${data.google_compute_address.default.address}"
 }
+
+output routing_tag_regional {
+  description = "The tag that any other instance will need to have in order to get the regional routing rule"
+  value       = "${var.name}nat-${var.region}"
+}
+
+output routing_tag_zonal {
+  description = "The tag that any other instance will need to have in order to get the zonal routing rule"
+  value       = "${var.name}nat-${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"
+}


### PR DESCRIPTION
# Problem

Currently it's just "voodoo" you have to just know the naming syntax to tag your instances to route through the NAT.  The name of this tag also currently includes the "name" that you pass into the module, which is not actually documented anywhere (in the old README).  So, I added a new output to this module which allows you to easily use the output for tagging your instances, so you don't have to do witchcraft to figure.  I also updated the README to clarify this with an example.  

Example:

```
module "nat" {
  source         = "github.com/AndrewFarley/terraform-google-nat-gateway"
  name           = "dev"
  region         = "${var.region}"
  zone           = "${var.zones}"
  network        = "${google_compute_subnetwork.default.name}"
  subnetwork     = "${google_compute_subnetwork.default.name}"
}

module "mig" {
  source             = "github.com/GoogleCloudPlatform/terraform-google-managed-instance-group"
  region             = "${var.region}"
  zone               = "${var.zone1}"
  name               = "testnat"
  target_tags        = ["${module.nat.routing_tag_regional}"]  <--- THIS
  network            = "${google_compute_subnetwork.default.name}"
  subnetwork         = "${google_compute_subnetwork.default.name}"
}
```