### PR TITLE
import of squid-proxy example and created variable for compute image

### DIFF
--- a/config/startup.sh
+++ b/config/startup.sh
@@ -18,9 +18,9 @@ ENABLE_SQUID="${squid_enabled}"
 if [[ "$$ENABLE_SQUID" == "true" ]]; then
   apt-get install -y squid3
 
-  cat - > /etc/squid3/squid.conf <<'EOM'
+  cat - > /etc/squid/squid.conf <<'EOM'
 ${file("${squid_config == "" ? "${format("%s/config/squid.conf", module_path)}" : squid_config}")}
 EOM
 
-  systemctl reload squid3
+  systemctl reload squid
 fi

--- a/examples/squid-proxy/main.tf
+++ b/examples/squid-proxy/main.tf
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable region {
+  default = "us-central1"
+}
+
+variable zone {
+  default = "us-central1-c"
+}
+
+variable "vm_image" {
+  default = "debian-cloud/debian-9"
+}
+
+provider google {
+  region = "${var.region}"
+}
+
+variable network_name {
+  default = "squid-nat-example"
+}
+
+resource "google_compute_network" "default" {
+  name                    = "${var.network_name}"
+  auto_create_subnetworks = "false"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name                     = "${var.network_name}"
+  ip_cidr_range            = "10.127.0.0/20"
+  network                  = "${google_compute_network.default.self_link}"
+  region                   = "${var.region}"
+  private_ip_google_access = true
+}
+
+module "nat" {
+  source        = "../../"
+  name          = "${var.network_name}-"
+  region        = "${var.region}"
+  zone          = "${var.zone}"
+  network       = "${google_compute_subnetwork.default.name}"
+  subnetwork    = "${google_compute_subnetwork.default.name}"
+  squid_enabled = "true"
+}
+
+resource "google_compute_instance" "vm" {
+  name                      = "${var.network_name}-vm"
+  zone                      = "${var.zone}"
+  tags                      = ["${var.network_name}-ssh", "${var.network_name}-squid"]
+  machine_type              = "f1-micro"
+  allow_stopping_for_update = true
+
+  boot_disk {
+    initialize_params {
+      image = "${var.vm_image}"
+    }
+  }
+
+  network_interface {
+    subnetwork    = "${google_compute_subnetwork.default.name}"
+    access_config = []
+  }
+}
+
+resource "google_compute_firewall" "vm-ssh" {
+  name    = "${var.network_name}-ssh"
+  network = "${google_compute_subnetwork.default.name}"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["${var.network_name}-ssh"]
+}
+
+// Since we aren't using the NAT on the test VM, add separate firewall rule for the squid proxy.
+resource "google_compute_firewall" "nat-squid" {
+  name    = "${var.network_name}-squid"
+  network = "${google_compute_subnetwork.default.name}"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["3128"]
+  }
+
+  source_tags = ["${var.network_name}-squid"]
+  target_tags = ["${var.network_name}-nat-${var.zone}"]
+}
+
+output "nat-host" {
+  value = "${module.nat.instance}"
+}
+
+output "nat-ip" {
+  value = "${module.nat.external_ip}"
+}
+
+output "vm-host" {
+  value = "${google_compute_instance.vm.self_link}"
+}

--- a/examples/squid-proxy/test.sh
+++ b/examples/squid-proxy/test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -e
+
+function cleanup() {
+  set +e
+  rm -f ssh_config
+  kill $ssh_pid
+  kill $SSH_AGENT_PID
+}
+trap cleanup EXIT
+
+NAT_IP=${EXTERNAL_IP:-$(terraform output nat-ip)}
+
+NAT_HOST_URI=${NAT_HOST:-$(terraform output nat-host)}
+NAT_HOST=${NAT_HOST_URI//*instances\//}
+REMOTE_HOST_URI=${REMOTE_HOST_URI:-$(terraform output vm-host)}
+REMOTE_HOST=${REMOTE_HOST_URI//*instances\//}
+REMOTE_ZONE=$(echo ${REMOTE_HOST_URI} | cut -d/ -f9)
+
+# Configure SSH
+SSH_USER_EMAIL=$(gcloud config get-value account)
+SSH_USER=${SSH_USER_EMAIL//@*}
+
+
+if [[ ! -f ${HOME}/.ssh/google_compute_engine ]]; then
+  mkdir -p ${HOME}/.ssh && chmod 0700 ${HOME}/.ssh && \
+  ssh-keygen -b 2048 -t rsa -f ${HOME}/.ssh/google_compute_engine -q -N "" -C ${SSH_USER_EMAIL}
+fi
+
+# Create ssh tunnel through NAT gateway.
+
+cat > ssh_config << EOF
+Host *
+    User ${SSH_USER}
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+
+Host remote
+    HostName ${NAT_IP}
+    ProxyCommand gcloud compute ssh ${SSH_USER}@${NAT_HOST_URI} --ssh-flag="-A -W ${REMOTE_HOST}:22"
+    LocalForward 3128 ${NAT_HOST}:3128
+EOF
+
+eval `ssh-agent`
+ssh-add ${HOME}/.ssh/google_compute_engine
+gcloud compute config-ssh
+ssh -N -F ssh_config remote &
+ssh_pid=$!
+
+echo "INFO: Verifying NAT IP through squid proxy: ${NAT_IP}"
+
+count=0
+while [[ $count -lt 120 ]]; do
+IP=$(curl -s --proxy localhost:3128 http://ipinfo.io/ip || true)
+if [[ "${IP}" == "${NAT_IP}" ]]; then
+    echo "INFO: Found NAT IP: ${IP}"      
+    break
+fi
+((count=count+1))
+sleep 1
+done
+test $count -lt 120
+
+echo "PASS: Egress from instance is routed through squid proxy."

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ module "nat-gateway" {
   target_tags        = ["${var.name}nat-${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"]
   machine_type       = "${var.machine_type}"
   name               = "${var.name}nat-gateway-${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"
-  compute_image      = "debian-cloud/debian-9"
+  compute_image      = "${var.compute_image}"
   size               = 1
   network_ip         = "${var.ip}"
   can_ip_forward     = "true"

--- a/variables.tf
+++ b/variables.tf
@@ -74,6 +74,11 @@ variable machine_type {
   default     = "n1-standard-1"
 }
 
+variable compute_image {
+  description = "Image used for NAT compute VMs."
+  default     = "debian-cloud/debian-9"
+}
+
 variable ip {
   description = "Override the IP used in the `region_params` map for the region."
   default     = ""


### PR DESCRIPTION
- fix broken squid install in startup script
- move compute image to variable

> NOTE: because the startup script changed, upgrading will trigger a recreation of the NAT gateway instance(s)