### PR TITLE
specify version for module managed-instance-group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ data "google_compute_address" "default" {
 
 module "nat-gateway" {
   source             = "GoogleCloudPlatform/managed-instance-group/google"
-  version            = "1.1.7"
+  version            = "1.1.8"
   module_enabled     = "${var.module_enabled}"
   project            = "${var.project}"
   region             = "${var.region}"

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,8 @@ data "google_compute_address" "default" {
 }
 
 module "nat-gateway" {
-  source             = "github.com/GoogleCloudPlatform/terraform-google-managed-instance-group"
+  source             = "GoogleCloudPlatform/managed-instance-group/google"
+  version            = "1.1.7"
   module_enabled     = "${var.module_enabled}"
   project            = "${var.project}"
   region             = "${var.region}"


### PR DESCRIPTION
Hi

I propose to set version for managed-instance-group

I think, that currently, Terraform doesn't allow dynamic value for version (with a variable), so you will have to track new version of this module ...

Thanks !