### PR TITLE
added a conditional to create or not the static external ip for nat

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ resource "google_compute_firewall" "nat-gateway" {
 }
 
 resource "google_compute_address" "default" {
-  count   = "${var.module_enabled && var.ip_address_name == "" ? 1 : 0}"
+  count   = "${var.module_enabled && var.static_ip_address && var.ip_address_name == "" ? 1 : 0}"
   name    = "${var.name}nat-${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"
   project = "${var.project}"
   region  = "${var.region}"

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,16 @@ module "nat-gateway" {
   ]
 }
 
+data "google_compute_instance_group" "nat-gateway" {
+  name = "${var.name}nat-gateway-${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"
+  zone = "${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"
+}
+
+data "google_compute_instance" "nat-gateway" {
+  name = "${element(data.google_compute_instance_group.nat-gateway.instances, 0)}"
+  zone = "${var.zone =  = "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"
+}
+
 resource "google_compute_route" "nat-gateway" {
   count                  = "${var.module_enabled ? 1 : 0}"
   name                   = "${var.name}nat-${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,7 +31,10 @@ output instance {
 
 output external_ip {
   description = "The external IP address of the NAT gateway instance."
-  value       = "${element(concat(google_compute_address.default.*.address, data.google_compute_address.default.*.address, list("")), 0)}"
+
+  value = "${element(concat(google_compute_address.default.*.address,
+      data.google_compute_address.default.*.address,
+      data.google_compute_instance.nat-gateway.*.address, 0)}"
 }
 
 output routing_tag_regional {

--- a/variables.tf
+++ b/variables.tf
@@ -100,6 +100,11 @@ variable metadata {
   default     = {}
 }
 
+variable static_ip_address {
+  description = "Whether or not the NAT should have a static external IP."
+  default     = true
+}
+
 variable ssh_source_ranges {
   description = "Network ranges to allow SSH from"
   type        = "list"


### PR DESCRIPTION
It's not mandatory to use a nat gateway with static external ip, some scenarios didn't need it.
This PR proposes a optional flag, to deactivate static external ip creation when you don't need it