### PR TITLE
disable autohealing by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,8 +67,9 @@ module "nat-gateway" {
   wait_for_instances = true
   metadata           = "${var.metadata}"
   ssh_source_ranges  = "${var.ssh_source_ranges}"
+  http_health_check  = "${var.autohealing_enabled}"
 
-  update_strategy    = "ROLLING_UPDATE"
+  update_strategy = "ROLLING_UPDATE"
 
   rolling_update_policy = [{
     type                  = "PROACTIVE"

--- a/variables.tf
+++ b/variables.tf
@@ -112,6 +112,11 @@ variable instance_labels {
   default     = {}
 }
 
+variable autohealing_enabled {
+  description = "Enable instance autohealing using http health check"
+  default     = false
+}
+
 variable region_params {
   description = "Map of default zones and IPs for each region. Can be overridden using the `zone` and `ip` variables."
   type        = "map"


### PR DESCRIPTION
Autohealing is currently a beta feature. When enabled, an HTTP health check is used to automatically recreate failed instances.

When enabled, the health check on the GCP side takes several many minutes to provision and often times out when creating. We will consider making this default enabled after the feature is GA. 

In the meantime, if the instance fails for other reasons, it will be recreated automatically by the instance group manager.

Upgrading existing deployments to use this will fail because of: https://github.com/terraform-providers/terraform-provider-google/issues/1883

Upgrade workaround is to do the following steps:
1. terraform init -upgrade=true
2. manually delete the health check from the GCP console or gcloud CLI.
3. terraform apply