### PR TITLE
Add rolling update strategy for incremental updates.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ locals {
 
 module "nat-gateway" {
   source             = "GoogleCloudPlatform/managed-instance-group/google"
-  version            = "1.1.11"
+  version            = "1.1.12"
   module_enabled     = "${var.module_enabled}"
   project            = "${var.project}"
   region             = "${var.region}"
@@ -67,6 +67,16 @@ module "nat-gateway" {
   wait_for_instances = true
   metadata           = "${var.metadata}"
   ssh_source_ranges  = "${var.ssh_source_ranges}"
+
+  update_strategy    = "ROLLING_UPDATE"
+
+  rolling_update_policy = [{
+    type                  = "PROACTIVE"
+    minimal_action        = "REPLACE"
+    max_surge_fixed       = 0
+    max_unavailable_fixed = 1
+    min_ready_sec         = 30
+  }]
 
   access_config = [
     {


### PR DESCRIPTION
Helps with incremental updates by performing an rolling update on the instance group.

Depends on managed instance group module version 1.1.12 to force refresh of instances in group when instance template changes.

There will be downtime in a single NAT deployment as the compute route is deleted and recreated after the instance is replaced. 
To avoid downtime, deploy multiple NAT gateways according to the [HA example](https://github.com/GoogleCloudPlatform/terraform-google-nat-gateway/tree/master/examples/ha-nat-gateway) and upgrade them one at a time. 