### PR TITLE
Fixed bastion variable

### DIFF
--- a/examples/ha-nat-gateway/README.md
+++ b/examples/ha-nat-gateway/README.md
@@ -27,7 +27,7 @@ SSH into the instance by hopping through one of the NAT gateway instances, first
 gcloud compute config-ssh
 eval `ssh-agent $SHELL`
 ssh-add ~/.ssh/google_compute_engine
-BASTION=$(terraform output -module nat-zone-1 -json | jq -r '.instance.value')
+BASTION=$(terraform output -module nat-zone-1 -json | jq -r '.instance.value[0]')
 REMOTE_HOST=$(terraform output -module mig1 -json | jq -r '.instances.value[0][0]')
 SSH_USER=$(gcloud config get-value account)
 gcloud compute ssh ${SSH_USER//@*}@${BASTION} --ssh-flag="-A" -- ssh ${REMOTE_HOST//*instances\//} -o StrictHostKeyChecking=no


### PR DESCRIPTION
The BASTION variable is assigned an array right now, we need the jq filter to pick up the first instance rather than the full list
'.instance.value[0]' rather than '.instance.value'