### PR TITLE
Enable subnetwork specification

### DIFF
--- a/examples/gke-ha-nat-gateway/main.tf
+++ b/examples/gke-ha-nat-gateway/main.tf
@@ -46,6 +46,10 @@ variable network {
   default = "default"
 }
 
+variable subnetwork {
+  default = ""
+}
+
 provider google {
   region = "${var.region}"
 }
@@ -57,7 +61,7 @@ module "nat-zone-1" {
   zone           = "${var.zone1}"
   tags           = ["${var.gke_node_tag}"]
   network        = "${var.network}"
-  subnetwork     = "${var.network}"
+  subnetwork     = "${var.subnetwork == "" ? var.network : var.subnetwork}"
   route_priority = 800
 }
 
@@ -68,7 +72,7 @@ module "nat-zone-2" {
   zone           = "${var.zone2}"
   tags           = ["${var.gke_node_tag}"]
   network        = "${var.network}"
-  subnetwork     = "${var.network}"
+  subnetwork     = "${var.subnetwork == "" ? var.network : var.subnetwork}"
   route_priority = 800
 }
 
@@ -79,7 +83,7 @@ module "nat-zone-3" {
   zone           = "${var.zone3}"
   tags           = ["${var.gke_node_tag}"]
   network        = "${var.network}"
-  subnetwork     = "${var.network}"
+  subnetwork     = "${var.subnetwork == "" ? var.network : var.subnetwork}"
   route_priority = 800
 }
 

--- a/examples/gke-nat-gateway/main.tf
+++ b/examples/gke-nat-gateway/main.tf
@@ -34,6 +34,10 @@ variable network {
   default = "default"
 }
 
+variable subnetwork {
+  default = "default"
+}
+
 provider google {
   region = "${var.region}"
 }
@@ -45,7 +49,7 @@ module "nat" {
   zone       = "${var.zone}"
   tags       = ["${var.gke_node_tag}"]
   network    = "${var.network}"
-  subnetwork = "${var.network}"
+  subnetwork = "${var.subnetwork}"
 }
 
 // Route so that traffic to the master goes through the default gateway.

--- a/examples/gke-nat-gateway/main.tf
+++ b/examples/gke-nat-gateway/main.tf
@@ -35,7 +35,7 @@ variable network {
 }
 
 variable subnetwork {
-  default = "default"
+  default = ""
 }
 
 provider google {
@@ -49,7 +49,7 @@ module "nat" {
   zone       = "${var.zone}"
   tags       = ["${var.gke_node_tag}"]
   network    = "${var.network}"
-  subnetwork = "${var.subnetwork}"
+  subnetwork = "${var.subnetwork == "" ? var.network : var.subnetwork}"
 }
 
 // Route so that traffic to the master goes through the default gateway.


### PR DESCRIPTION
Enable subnetwork specification.

I attempted to specify subnetwork for terraform.tfvars, but because it was set to overwrite subnetwork with network, it was an error if the network name and subnetwork name were different.

```
subnetwork = "${var.network}"
```

Added variable of subnetwork.