### PR TITLE
Changes compute_image to prevent rebuilds

### DIFF
--- a/examples/module-disable/main.tf
+++ b/examples/module-disable/main.tf
@@ -27,7 +27,7 @@ variable "module_enabled" {
 }
 
 variable "vm_image" {
-  default = "debian-cloud/debian-9"
+  default = "projects/debian-cloud/global/images/family/debian-9"
 }
 
 provider google {

--- a/examples/squid-proxy/main.tf
+++ b/examples/squid-proxy/main.tf
@@ -23,7 +23,7 @@ variable zone {
 }
 
 variable "vm_image" {
-  default = "debian-cloud/debian-9"
+  default = "projects/debian-cloud/global/images/family/debian-9"
 }
 
 provider google {

--- a/variables.tf
+++ b/variables.tf
@@ -76,7 +76,7 @@ variable machine_type {
 
 variable compute_image {
   description = "Image used for NAT compute VMs."
-  default     = "debian-cloud/debian-9"
+  default     = "projects/debian-cloud/global/images/family/debian-9"
 }
 
 variable ip {


### PR DESCRIPTION
Changes compute_image from debian-cloud/debian-9 to projects/debian-cloud/global/images/family/debian-9 to prevent Terraform from constantly wanting to rebuild the nat instances.