### PR TITLE
Adding disk type and size variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,8 @@ module "nat-gateway" {
   instance_labels       = "${var.instance_labels}"
   service_account_email = "${var.service_account_email}"
   machine_type          = "${var.machine_type}"
+  disk_type             = "${var.disk_type}"
+  disk_size_gb          = "${var.disk_size_gb}"
   name                  = "${local.name}"
   compute_image         = "${var.compute_image}"
   size                  = 1

--- a/variables.tf
+++ b/variables.tf
@@ -74,6 +74,16 @@ variable machine_type {
   default     = "n1-standard-1"
 }
 
+variable disk_type {
+  description = "The GCE disk type. Can be either pd-ssd, local-ssd, or pd-standard."
+  default     = "pd-ssd"
+}
+
+variable disk_size_gb {
+  description = "The size of the image in gigabytes. If not specified, it will inherit the size of its base image."
+  default     = 0
+}
+
 variable compute_image {
   description = "Image used for NAT compute VMs."
   default     = "projects/debian-cloud/global/images/family/debian-9"


### PR DESCRIPTION
I'd like to save a few bucks per month and set `disk_type` to `pd-standard`...also added `disk_size_gb` for consistency with the `managed-instance-group` module.