### PR TITLE
New instances don't have an eth0 interface

### DIFF
--- a/config/startup.sh
+++ b/config/startup.sh
@@ -6,7 +6,7 @@ sysctl -w net.ipv4.ip_forward=1
 # Make forwarding persistent.
 sed -i= 's/^[# ]*net.ipv4.ip_forward=[[:digit:]]/net.ipv4.ip_forward=1/g' /etc/sysctl.conf
 
-iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+iptables -t nat -A POSTROUTING -o ens4 -j MASQUERADE
 
 apt-get update
 


### PR DESCRIPTION
The instances created by this module don't have an eth0 interface so the forwarding rule isn't working. 