### PR TITLE
Added europe-west6 to region_params

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -176,6 +176,10 @@ variable region_params {
       zone = "europe-west4-b"
     }
 
+    europe-west6 = {
+      zone = "europe-west6-b"
+    }
+
     northamerica-northeast1 = {
       zone = "northamerica-northeast1-b"
     }


### PR DESCRIPTION
Without defining europe-west6 in region_params terraform fails with the following message:

`${var.zone == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}`