### PR TITLE
added region europe-west6 to region_params

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -175,6 +175,10 @@ variable region_params {
     europe-west4 = {
       zone = "europe-west4-b"
     }
+    
+    europe-west6 = {
+      zone = "europe-west6-b"
+    }
 
     northamerica-northeast1 = {
       zone = "northamerica-northeast1-b"


### PR DESCRIPTION
Without defining europe-west6 in region_params terraform fails with the following message:

`${var.zone` == "" ? lookup(var.region_params["${var.region}"], "zone") : var.zone}`