### PR TITLE
Adding version lock to the Google Provider

### DIFF
--- a/examples/gke-nat-gateway/main.tf
+++ b/examples/gke-nat-gateway/main.tf
@@ -40,6 +40,7 @@ variable subnetwork {
 
 provider google {
   region = "${var.region}"
+  version = "1.18"
 }
 
 module "nat" {


### PR DESCRIPTION
The "Using a NAT Gateway with Kubernetes Engine" is currently broken due to an error in the current Google provider. It needs to be locked to version 1.18 for the solution to not need a complete re-write.